### PR TITLE
add docker build scripts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --rm -ti -v $(pwd):/go/build -e GIT_SSL_NO_VERIFY=1 -e GOBIN=/go/bin golang bash /go/build/script.sh

--- a/script.sh
+++ b/script.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -e
+
+cd /go/build
+go get github.com/coreos/go-etcd/etcd
+go install 
+mv /go/bin/build /go/build/etcd-backup


### PR DESCRIPTION
These shell scripts add an easy way to compile the linux binaries using the docker golang container.
This PR should fix #5 